### PR TITLE
Backward incompatible api change

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 https://sendgrid.com/
 
+# Installation
 On Quicklisp (2020-10):
 
     (ql:quickload "sendgrid")
 
 and on [Ultralisp](https://ultralisp.org/).
 
-Create an account an set these variables:
+# Current usage (Please jump to [Updated usage](#updated-usage) to see upcoming changes)
+Create a SendGrid account and set these variables:
 
 ```lisp
 (setf *email-config*
@@ -35,11 +37,51 @@ Send an email with `send-email`:
 
 It takes the time of a POST request.
 
-TODO:
-
-- [X] make the "to" parameter accept a list of addresses.
-- [X] add "reply_to". It is a cons cell / a list with: an email address, a name.
-
+# Updated usage
+## API KEY
+After obtaining an API key from [SendGrid](https://sendgrid.com/), you can either 
+### Provide the API key via an Operating System environment variable
+```lisp
+CL-USER> sendgrid:*api-key-environment-variable-name*
+"SENDGRID_API_KEY" ; default environment variable name, you can change it.
+```
+Then you can do it by OS built-in facility, such as
+```bash
+export SENDGRID_API_KEY=your_sendgrid_api_key_value
+```
+Or set it using UIOP
+```lisp
+CL-USER> (setf (uiop:getenv sendgrid:*api-key-environment-variable-name*) your-api-key-value)
+```
+### Provide the API key when calling ```sendgrid:send-mail```
+```api-key``` is one of the parameter of ```sendgrid:send-mail```
+```lisp
+(sendgrid:send-email &rest rest
+                     &key
+                     to
+                     from
+                     subject
+                     content
+                     reply-to ; if not nil, should be an alist as (("email" . string) ("name" . string))
+                     (content-type "text/plain")
+                     (api-key (uiop:getenv *api-key-environment-variable-name*))
+                   &allow-other-keys)
+```
+## Sample plain text email
+```lisp
+(sendgrid:send-email :to "recipient@example.com"
+                     :from "noreply@example.com"
+                     :subject "Sending emails from SendGrid is fun!"
+                     :content "Sending emails from SendGrid is fun!")
+```
+## Sample html email
+```lisp
+(sendgrid:send-email :to "recipient@example.com"
+                     :from "noreply@example.com"
+                     :subject "Sending emails from SendGrid is fun!"
+                     :content-type "text/html"
+                     :content "<h1>A title</h1><br/><strong>Sending emails from SendGrid is fun!</strong>")
+```
 # See also
 
 * https://github.com/40ants/mailgun (Mailgun: just a bit more overhead to getting started, a free plan a bit less free)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ CL-USER> (setf (uiop:getenv sendgrid:*api-key-environment-variable-name*) your-a
                      :subject "Sending emails from SendGrid is fun!"
                      :content "Sending emails from SendGrid is fun!")
 ```
-## Sample html email
+## Sample HTML email
 ```lisp
 (sendgrid:send-email :to "recipient@example.com"
                      :from "noreply@example.com"
@@ -82,11 +82,20 @@ CL-USER> (setf (uiop:getenv sendgrid:*api-key-environment-variable-name*) your-a
                      :content-type "text/html"
                      :content "<h1>A title</h1><br/><strong>Sending emails from SendGrid is fun!</strong>")
 ```
+## Verbose mode example
+```
+(let ((sendgrid:*verbose* t))
+  (sendgrid:send-email :to "recipient@example.com"
+                       :from "noreply@example.com"
+                       :subject "Sending emails from SendGrid is fun!"
+                       :content-type "text/html"
+                       :content "<h1>A title</h1><br/><strong>Sending emails from SendGrid is fun!</strong>"))
+```
 # See also
 
 * https://github.com/40ants/mailgun (Mailgun: just a bit more overhead to getting started, a free plan a bit less free)
 * https://github.com/CodyReichert/awesome-cl#email
-
+* [spinneret](https://github.com/ruricolist/spinneret) (recommended) or [cl-who](https://edicl.github.io/cl-who/) for generating HTML strings.
 # Licence
 
 MIT.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,18 @@ CL-USER> (setf (uiop:getenv sendgrid:*api-key-environment-variable-name*) your-a
                    &allow-other-keys)
 ```
 ## Sample plain text email
+### Minimum
 ```lisp
 (sendgrid:send-email :to "recipient@example.com"
                      :from "noreply@example.com"
+                     :subject "Sending emails from SendGrid is fun!"
+                     :content "Sending emails from SendGrid is fun!")
+```
+### With ```reply-to```
+```lisp
+(sendgrid:send-email :to "recipient@example.com"
+                     :from "team@example.com"
+                     :reply-to '(("email" . "noreply@example.com") ("name" . "No Reply"))
                      :subject "Sending emails from SendGrid is fun!"
                      :content "Sending emails from SendGrid is fun!")
 ```

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Or set it using UIOP
 ```lisp
 CL-USER> (setf (uiop:getenv sendgrid:*api-key-environment-variable-name*) your-api-key-value)
 ```
-### Provide the API key when calling ```sendgrid:send-mail```
-```api-key``` is one of the parameter of ```sendgrid:send-mail```
+### Provide the API key when calling `sendgrid:send-mail`
+`api-key` is one of the parameter of `sendgrid:send-mail`
 ```lisp
 (sendgrid:send-email &rest rest
                      &key
@@ -75,7 +75,7 @@ CL-USER> (setf (uiop:getenv sendgrid:*api-key-environment-variable-name*) your-a
                      :subject "Sending emails from SendGrid is fun!"
                      :content "Sending emails from SendGrid is fun!")
 ```
-### With ```reply-to```
+### With `reply-to`
 ```lisp
 (sendgrid:send-email :to "recipient@example.com"
                      :from "team@example.com"

--- a/src/sendgrid.lisp
+++ b/src/sendgrid.lisp
@@ -89,12 +89,12 @@ The JSON looks like:
                      subject
                      (content-type "text/plain")
                      content
-                     (verbose *verbose*))
   "Send an email with SendGrid's API.
 
   -`from': from the `*email-config*' by default.
   - `reply-to': must be a list with an email address and a name.
                      (api-key (uiop:getenv *api-key-environment-variable-name*))
+                   &allow-other-keys) ; &allow-other-keys can help gradual API updates.
 
   todo: make `to' accept multiple addresses."
   (assert (and to from subject content))
@@ -104,10 +104,10 @@ The JSON looks like:
                                             "Bearer "
                                             api-key))
                        ("content-Type" . "application/json"))
-            :verbose verbose
             :content (sendgrid-json :to to
                                     :from from
                                     :reply-to reply-to
                                     :subject subject
                                     :content-value content
                                     :content-type content-type)))
+            :verbose *verbose*

--- a/src/sendgrid.lisp
+++ b/src/sendgrid.lisp
@@ -51,63 +51,73 @@ The JSON looks like:
       list
       (list list)))
 
-(defun sendgrid-json (&key to from reply-to subject content-type content-value)
+(defun sendgrid-json (&key
+                        to
+                        from
+                        reply-to
+                        subject
+                        (content-type "text/plain") ; this duplication is a-must. &rest doesn't pass the default value of caller's keys.
+                        content-value
+                      &allow-other-keys)
   "Build the data json.
   `to': one email address or a list.
   `reply-to': a pair of email and name."
-  (unless (or nil (consp reply-to))
-    (error "\"reply-to\" must be a pair with an email and a name (strings)."))
-  (setf to (ensure-list to))
-  (let ((json-alist
-         `(("personalizations"
-            ,(loop for dest in to
-                collect `("to" (("email" . ,dest)))))
-           ("from" ("email" . ,from))
-           ("reply_to" ("email" . ,(car reply-to))
-                       ("name" . ,(cadr reply-to)))
-           ("subject" . ,subject)
-           ("content" (("type" . ,content-type)
-                       ("value" . ,content-value))))))
+  (assert (and to
+               from
+               subject
+               content-value))
+  (unless (or (null reply-to)
+              (and (stringp (cdr (assoc "email"
+                                        reply-to
+                                        :test #'string=)))
+                   (stringp (cdr (assoc "name"
+                                        reply-to
+                                        :test #'string=)))))
+    (error "\"reply-to\" must be an alist pair as ((\"email\" . string) (\"name\" . string))"))
+  (let* ((to (ensure-list to))
+         (json-alist
+           (append `(("personalizations"
+                      ,(loop for dest in to
+                             collect `("to" (("email" . ,dest)))))
+                     ("from" ("email" . ,from)))
+                   (when reply-to
+                     `(,(cons "reply_to" reply-to)))
+                   `(("subject" . ,subject)
+                     ("content" (("type" . ,content-type)
+                                 ("value" . ,content-value)))))))
     (jonathan:to-json json-alist :from :alist)))
 
 ;; test:
 #+nil
 (progn
   ;; Base case:
-  (assert (string-equal (sendgrid-json :to "to@mail" :from "me@mail" :subject "hello" :content-value "yo" :reply-to '("@" "me"))
+  (assert (string-equal (sendgrid-json :to "to@mail" :from "me@mail" :subject "hello" :content-value "yo" :reply-to '(("email" . "@") ("name" . "me")))
                         "{\"personalizations\":[{\"to\":[{\"email\":\"to@mail\"}]}],\"from\":{\"email\":\"me@mail\"},\"reply_to\":{\"email\":\"@\",\"name\":\"me\"},\"subject\":\"hello\",\"content\":[{\"type\":\"text/plain\",\"value\":\"yo\"}]}"))
 
   ;; With two receivers:
-  (assert (string-equal (sendgrid-json :to '("to@mail" "to-two@mail") :from "me@mail" :subject "hello" :content-value "yo" :reply-to '("@" "me"))
+  (assert (string-equal (sendgrid-json :to '("to@mail" "to-two@mail") :from "me@mail" :subject "hello" :content-value "yo" :reply-to '(("email" . "@") ("name" . "me")))
                         "{\"personalizations\":[{\"to\":[{\"email\":\"to@mail\"}],\"to\":[{\"email\":\"to-two@mail\"}]}],\"from\":{\"email\":\"me@mail\"},\"reply_to\":{\"email\":\"@\",\"name\":\"me\"},\"subject\":\"hello\",\"content\":[{\"type\":\"text/plain\",\"value\":\"yo\"}]}")))
 
-
-(defun send-email (&key
+(defun send-email (&rest rest
+                   &key
                      to
-                     (from (getf *email-config* :|from|))
-                     (reply-to (getf *email-config* :|reply-to|))
+                     from
                      subject
-                     (content-type "text/plain")
                      content
-  "Send an email with SendGrid's API.
-
-  -`from': from the `*email-config*' by default.
-  - `reply-to': must be a list with an email address and a name.
+                     reply-to
+                     (content-type "text/plain")
                      (api-key (uiop:getenv *api-key-environment-variable-name*))
                    &allow-other-keys) ; &allow-other-keys can help gradual API updates.
+  "Send an email with SendGrid's API. https://docs.sendgrid.com/api-reference/mail-send/mail-send#body Currently only supporting basic parameters for 80% use cases.
 
-  todo: make `to' accept multiple addresses."
-  (assert (and to from subject content))
+ Notice that `reply-to', if not nil, should be an alist as ((\"email\" . string) (\"name\" . string))"
   (dex:post *sendgrid-api*
             :headers `(("Authorization" . ,(concatenate
                                             'string
                                             "Bearer "
                                             api-key))
                        ("content-Type" . "application/json"))
-            :content (sendgrid-json :to to
-                                    :from from
-                                    :reply-to reply-to
-                                    :subject subject
-                                    :content-value content
-                                    :content-type content-type)))
             :verbose *verbose*
+            :content (apply #'sendgrid-json
+                            (append `(:content-value ,content)
+                                    rest)))) ; The compiler might warn variables defined but never used. But keeping the warnings should be better for future code modification. E.g., suppressing the warnings by (declare (ignorable ...) could result in debugging difficulties once the API changes.

--- a/src/sendgrid.lisp
+++ b/src/sendgrid.lisp
@@ -7,10 +7,10 @@
 
 ;;; Send an email with SendGrid's API.
 
-(defparameter *api-key-environment-variable-name*
-  "SENDGRID_API_KEY")
-
 (defparameter *sendgrid-api* "https://api.sendgrid.com/v3/mail/send")
+
+(defvar *api-key-environment-variable-name*
+  "SENDGRID_API_KEY")
 
 (defvar *verbose* nil)
 

--- a/src/sendgrid.lisp
+++ b/src/sendgrid.lisp
@@ -1,9 +1,8 @@
 (defpackage sendgrid
   (:use :cl)
-  (:export
-   :send-email
-   :*email-config*))
-
+  (:export #:send-email
+           #:*api-key-environment-variable-name*
+           #:*verbose*))
 (in-package :sendgrid)
 
 ;;; Send an email with SendGrid's API.

--- a/src/sendgrid.lisp
+++ b/src/sendgrid.lisp
@@ -8,13 +8,13 @@
 
 ;;; Send an email with SendGrid's API.
 
-(defparameter *email-config*
+(defvar *email-config*
   '(:|api-key| ""
     :|from| ""))
 
 (defparameter *sendgrid-api* "https://api.sendgrid.com/v3/mail/send")
 
-(defparameter *verbose* nil)
+(defvar *verbose* nil)
 
 #|
 The JSON looks like:

--- a/src/sendgrid.lisp
+++ b/src/sendgrid.lisp
@@ -7,9 +7,8 @@
 
 ;;; Send an email with SendGrid's API.
 
-(defvar *email-config*
-  '(:|api-key| ""
-    :|from| ""))
+(defparameter *api-key-environment-variable-name*
+  "SENDGRID_API_KEY")
 
 (defparameter *sendgrid-api* "https://api.sendgrid.com/v3/mail/send")
 
@@ -90,12 +89,12 @@ The JSON looks like:
                      subject
                      (content-type "text/plain")
                      content
-                     (api-key (getf *email-config* :|api-key|))
                      (verbose *verbose*))
   "Send an email with SendGrid's API.
 
   -`from': from the `*email-config*' by default.
   - `reply-to': must be a list with an email address and a name.
+                     (api-key (uiop:getenv *api-key-environment-variable-name*))
 
   todo: make `to' accept multiple addresses."
   (assert (and to from subject content))


### PR DESCRIPTION
1. Supporting content-type ```"text/html"```.
2. Supporting API Key management by environment variables. This should be good enough for #2 
3. ```reply-to``` becoming an ALIST of ```(("email" . string) (\"name" . string))``` or ```nil```, with a sample code in the updated README.md. Notice that the original type check had a bug that ```(or nil (consp reply-to))``` was only ```(consp reply-to)```.
4. Defining ```*verbose*``` by ```defvar``` instead of ```defparameter```.  I think developers would like to keep this debug setting across reloads
5. Removing ```verbose``` from parameter of ```send-mail```, as ```*verbose*``` is already a special variable developers can bind. (With a sample put in README.md).
6. More documentations on README.md

Others are coding styles tweaks. Happy to hear any of your thoughts. Thanks!